### PR TITLE
Part 2 - add some new piracy events

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to MarineHQ
+
+Thank you for considering contributing to MarineHQ! We welcome contributions of all kinds, especially code changes and new event tracking features.
+
+## Local Development Setup
+
+To contribute code, you need a working [Node.js](https://nodejs.org/en) and [Docker](https://www.docker.com/get-started) setup. Follow these steps to set up the project locally:
+
+1. **Clone the Repository**:
+   Clone the repository to your local machine:
+
+   ```bash
+   git clone https://github.com/marinehq/marinehq.git
+   cd marinehq
+   ```
+
+2. **Create a Local `config.json` following the explanation in the [README](./README.md).**
+
+3. **Install Dependencies**:
+
+   ```bash
+   npm install
+   ```
+
+4. **Run the Project**:
+
+   ```bash
+   npm start
+   ```
+
+⚠️ work in progress ⚠️

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,38 @@
 
 Thank you for considering contributing to MarineHQ! We welcome contributions of all kinds, especially code changes and new event tracking features.
 
+## Adding New Acts of Piracy
+
+To add a new act of piracy to be tracked, follow these steps:
+
+1. **Update the `PiracyActs` File**:
+   Open the `/src/commands/piracy-acts.ts` file and add your new act to the `PiracyActs` array. Use the following format and place it in the appropriate category section:
+
+   ```typescript
+   {
+     name: '<unique-act-name>',
+     bounty: <bounty-value>,
+     description: '<description-of-the-act>',
+     category: '<category>'
+   }
+   ```
+
+   For example, if you want to add an act called "sky-pirate" with a bounty of 4000, the description "Win a game using only flying characters," and the category "Blue," you would add:
+
+   ```typescript
+   {
+     name: 'sky-pirate',
+     bounty: 4000,
+     description: 'Win a game using only flying characters',
+     category: 'Blue'
+   }
+   ```
+
+   As a rule of thumb: an easily achievable act should be worth 1000 or 2000, and mid-difficulty should be around 5000-6000 and something very silly or mega complicated can even go up to 10000.
+
+2. **Submit a Pull Request**:
+   Once you've added the act, submit a pull request. If the value and description are deemed worthy, it will be included in the project.
+
 ## Local Development Setup
 
 To contribute code, you need a working [Node.js](https://nodejs.org/en) and [Docker](https://www.docker.com/get-started) setup. Follow these steps to set up the project locally:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,29 @@
 # MarineHQ - OPTCG Bounty Bot
 
-This is a Discord Bot for OPTCG communities to use if they want to run their own 'Bounty Board' for the players, as a sort of mini-game alongside tournaments and casual games.
+This is a fan-made Discord Bot for the [One Piece trading card game](https://en.onepiece-cardgame.com) communities to use if they want to run their own 'Bounty Board' as a sort of mini-game alongside tournaments and casual events.
 
-## Usage
+## Demo
 
 https://github.com/LoveGlitchCoffee/marinehq/assets/10636469/a6781c31-d034-41f8-93e2-40141620fe0f
 
-## Installation
-To run this bot as your own, you will need to set up `config.json` in the `src` to use:
+## Setup
+
+To run this bot for your own community, you will need to set up `config.json` in the `src` to use:
+
 1. Your own Discord App's ID and Token
-2. A PSQL database endpoint (I use neon.tech), and a table called `pirates` matching the columns `(pirate_name, username, bounty, image_url, poster_url)`
-3. An image host that runs on chevereto API (I use freeimage.host)
+2. A PSQL database endpoint (such as [neon.tech](https://neon.tech)), and a table called `pirates` matching the columns `(pirate_name, username, bounty, image_url, poster_url)`
+3. An image host that runs on [chevereto API](https://chevereto.com) (such as [freeimage.host](https://freeimage.host))
 4. Somewhere to host the bot
 
-## Credits
-This Discord Bot was made by Hung Hoang for Spellbound Games OPTCG community.
+## Contributing
 
-[One Piece Poster Generator](https://github.com/YuskaWu/one-piece-wanted-poster) by YuskaWu
+If you want to improve the code, or add some new events to score, please check out [CONTRIBUTING](./CONTRIBUTING.md).
+
+## Credits
+
+This Discord Bot was made by Hung Hoang for [Spellbound Games](https://spellboundgames.co.uk)' OPTCG community.
+
+Projects leveraged by this bot:
+
+* [One Piece Poster Generator](https://github.com/YuskaWu/one-piece-wanted-poster) by YuskaWu
+* [discordjs](https://discord.js.org)

--- a/README.md
+++ b/README.md
@@ -57,3 +57,7 @@ Projects leveraged by this bot:
 
 - [One Piece Poster Generator](https://github.com/YuskaWu/one-piece-wanted-poster) by YuskaWu
 - [discord.js](https://discord.js.org)
+
+The literal information presented on this site about One Piece is copyright Bandai Namco Entertainment, Bird Studio/Shueisha and Toei Animation respectively.
+
+This bot is not produced by, endorsed by, supported by, or affiliated with Bandai Namco Entertainment, Bird Studio/Shueisha or Toei Animation.

--- a/README.md
+++ b/README.md
@@ -45,11 +45,15 @@ Once these steps are complete, you can start the bot and enjoy running your own 
 
 If you want to improve the code, or add some new events to score, please check out [CONTRIBUTING](./CONTRIBUTING.md).
 
+## License
+
+This project is licensed under the [MIT License](./LICENSE).
+
 ## Credits
 
-This Discord Bot was made by Hung Hoang for [Spellbound Games](https://spellboundgames.co.uk)' OPTCG community.
+This Discord Bot was created by Hung Hoang for [Spellbound Games](https://spellboundgames.co.uk)' OPTCG community.
 
 Projects leveraged by this bot:
 
-* [One Pie-e Poster Generator](https://github.com/YuskaWu/one-piece-wanted-poster) by YuskaWu
-* [discord-s](https://discord.js.org)
+- [One Piece Poster Generator](https://github.com/YuskaWu/one-piece-wanted-poster) by YuskaWu
+- [discord.js](https://discord.js.org)

--- a/README.md
+++ b/README.md
@@ -2,18 +2,44 @@
 
 This is a fan-made Discord Bot for the [One Piece trading card game](https://en.onepiece-cardgame.com) communities to use if they want to run their own 'Bounty Board' as a sort of mini-game alongside tournaments and casual events.
 
+For example, [this is how it's being used](https://spellboundgames.co.uk/pages/one-piece-bounty-board) at Spellbound Games in London, UK.
+
 ## Demo
 
 https://github.com/LoveGlitchCoffee/marinehq/assets/10636469/a6781c31-d034-41f8-93e2-40141620fe0f
 
 ## Setup
 
-To run this bot for your own community, you will need to set up `config.json` in the `src` to use:
+To set up and run this bot for your community, follow these steps:
 
-1. Your own Discord App's ID and Token
-2. A PSQL database endpoint (such as [neon.tech](https://neon.tech)), and a table called `pirates` matching the columns `(pirate_name, username, bounty, image_url, poster_url)`
-3. An image host that runs on [chevereto API](https://chevereto.com) (such as [freeimage.host](https://freeimage.host))
-4. Somewhere to host the bot
+### 1. Requirements
+
+- **Discord App Credentials**: Obtain your Discord App's `clientID` and `discordToken` from the [Discord Developer Portal](https://discord.com/developers/applications).
+- **Database**: Set up a PostgreSQL database (e.g., via [neon.tech](https://neon.tech)) with a table named `pirates` that includes the following columns:
+  - `pirate_name`
+  - `username`
+  - `bounty`
+  - `image_url`
+  - `poster_url`
+- **Image Hosting**: Use an image hosting service that supports the [Chevereto API](https://chevereto.com) (e.g., [freeimage.host](https://freeimage.host)).
+- **Hosting Environment**: Deploy the bot to a hosting platform of your choice (e.g., [Heroku](https://www.heroku.com), [Railway](https://railway.app), or a self-hosted server).
+
+### 2. Configure `config.json`
+
+Create a `config.json` file in the `src` directory with the following structure and populate the fields as described:
+
+```json
+{
+  "DATABASE_URL": "<Your PostgreSQL database connection string>",
+  "discordToken": "<Your Discord bot token>",
+  "testClientID": "<Your test Discord application client ID>",
+  "clientID": "<Your production Discord application client ID>",
+  "imageHostRequestUrl": "<The API endpoint of your image hosting service>",
+  "imageAPIKey": "<The API key for your image hosting service>"
+}
+```
+
+Once these steps are complete, you can start the bot and enjoy running your own Bounty Board!
 
 ## Contributing
 
@@ -25,5 +51,5 @@ This Discord Bot was made by Hung Hoang for [Spellbound Games](https://spellboun
 
 Projects leveraged by this bot:
 
-* [One Piece Poster Generator](https://github.com/YuskaWu/one-piece-wanted-poster) by YuskaWu
-* [discordjs](https://discord.js.org)
+* [One Pie-e Poster Generator](https://github.com/YuskaWu/one-piece-wanted-poster) by YuskaWu
+* [discord-s](https://discord.js.org)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "discord.js": "^14.13.0",
         "image-to-base64": "^2.2.0",
         "postgres": "^3.4.0",
-        "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
       },
       "devDependencies": {
@@ -22,10 +21,11 @@
         "@typescript-eslint/parser": "^6.7.4",
         "eslint": "^8.50.0",
         "prettier": "3.0.3",
-        "prettier-plugin-jsdoc": "^1.0.2"
+        "prettier-plugin-jsdoc": "^1.0.2",
+        "ts-node": "^10.9.1"
       },
       "engines": {
-        "node": "18.9.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -41,6 +41,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -49,85 +50,130 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.5.tgz",
-      "integrity": "sha512-SdweyCs/+mHj+PNhGLLle7RrRFX9ZAhzynHahMCLqp5Zeq7np7XC6/mgzHc79QoVlQ1zZtOkTTiJpOZu5V8Ufg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.10.1.tgz",
+      "integrity": "sha512-OWo1fY4ztL1/M/DUyRPShB4d/EzVfuUvPTRRHRIt/YxBrUYSz0a+JicD5F5zHFoNs2oTuWavxCOVFV1UljHTng==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@discordjs/formatters": "^0.3.2",
-        "@discordjs/util": "^1.0.1",
-        "@sapphire/shapeshift": "^3.9.2",
-        "discord-api-types": "0.37.50",
+        "@discordjs/formatters": "^0.6.0",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.37.119",
         "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.3",
-        "tslib": "^2.6.1"
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
       },
       "engines": {
         "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/collection": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
       "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=16.11.0"
       }
     },
     "node_modules/@discordjs/formatters": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.2.tgz",
-      "integrity": "sha512-lE++JZK8LSSDRM5nLjhuvWhGuKiXqu+JZ/DsOR89DVVia3z9fdCJVcHF2W/1Zxgq0re7kCzmAJlCMMX3tetKpA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.0.tgz",
+      "integrity": "sha512-YIruKw4UILt/ivO4uISmrGq2GdMY6EkoTtD0oS0GvkJFRZbTSdPhzYiUILbJ/QslsvC9H9nTgGgnarnIl4jMfw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "discord-api-types": "0.37.50"
+        "discord-api-types": "^0.37.114"
       },
       "engines": {
         "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/rest": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.0.1.tgz",
-      "integrity": "sha512-/eWAdDRvwX/rIE2tuQUmKaxmWeHmGealttIzGzlYfI4+a7y9b6ZoMp8BG/jaohs8D8iEnCNYaZiOFLVFLQb8Zg==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.4.3.tgz",
+      "integrity": "sha512-+SO4RKvWsM+y8uFHgYQrcTl/3+cY02uQOH7/7bKbVZsTfrfpoE62o5p+mmV+s7FVhTX82/kQUGGbu4YlV60RtA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@discordjs/collection": "^1.5.3",
-        "@discordjs/util": "^1.0.1",
-        "@sapphire/async-queue": "^1.5.0",
-        "@sapphire/snowflake": "^3.5.1",
-        "@vladfrangu/async_event_emitter": "^2.2.2",
-        "discord-api-types": "0.37.50",
-        "magic-bytes.js": "^1.0.15",
-        "tslib": "^2.6.1",
-        "undici": "5.22.1"
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.37.119",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.1"
       },
       "engines": {
-        "node": ">=16.11.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/util": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.1.tgz",
-      "integrity": "sha512-d0N2yCxB8r4bn00/hvFZwM7goDcUhtViC5un4hPj73Ba4yrChLSJD8fy7Ps5jpTLg1fE9n4K0xBLc1y9WGwSsA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1.tgz",
+      "integrity": "sha512-eddz6UnOBEB1oITPinyrB2Pttej49M9FZQY8NxgEvc3tq6ZICZ19m70RsmzRdDHk80O9NoYN/25AqJl8vPVf/g==",
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=16.11.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/ws": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.0.1.tgz",
-      "integrity": "sha512-avvAolBqN3yrSvdBPcJ/0j2g42ABzrv3PEL76e3YTp2WYMGH7cuspkjfSyNWaqYl1J+669dlLp+YFMxSVQyS5g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.1.tgz",
+      "integrity": "sha512-PBvenhZG56a6tMWF/f4P6f4GxZKJTBG95n7aiGSPTnodmz4N5g60t79rSIAq7ywMbv8A4jFtexMruH+oe51aQQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@discordjs/collection": "^1.5.3",
-        "@discordjs/rest": "^2.0.1",
-        "@discordjs/util": "^1.0.1",
-        "@sapphire/async-queue": "^1.5.0",
-        "@types/ws": "^8.5.5",
-        "@vladfrangu/async_event_emitter": "^2.2.2",
-        "discord-api-types": "0.37.50",
-        "tslib": "^2.6.1",
-        "ws": "^8.13.0"
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.4.3",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.37.119",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
       },
       "engines": {
         "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -254,6 +300,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
       "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -261,12 +308,14 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -308,31 +357,33 @@
       }
     },
     "node_modules/@sapphire/async-queue": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
-      "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "license": "MIT",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@sapphire/shapeshift": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.2.tgz",
-      "integrity": "sha512-YRbCXWy969oGIdqR/wha62eX8GNHsvyYi0Rfd4rNW6tSVVa8p0ELiMEuOH/k8rgtvRoM+EMV7Csqz77YdwiDpA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "lodash": "^4.17.21"
       },
       "engines": {
-        "node": ">=v14.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=v16"
       }
     },
     "node_modules/@sapphire/snowflake": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.1.tgz",
-      "integrity": "sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -341,22 +392,26 @@
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
     },
     "node_modules/@types/debug": {
       "version": "4.1.9",
@@ -406,9 +461,10 @@
       "dev": true
     },
     "node_modules/@types/ws": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.6.tgz",
-      "integrity": "sha512-8B5EO9jLVCy+B58PLHvLDuOD8DRVMgQzq8d55SjLCOn9kqGyqOvy27exVaTio1q1nX5zLu8/6N0n2ThSxOM6tg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8svvI3hMyvN0kKCJMvTJP/x6Y/EoQbepff882wL+Sn5QsXb3etnamgrJq4isrBxSJj5L2AuXcI0+bgkoAXGUJw==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -603,9 +659,10 @@
       }
     },
     "node_modules/@vladfrangu/async_event_emitter": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.2.tgz",
-      "integrity": "sha512-HIzRG7sy88UZjBJamssEczH5q7t5+axva19UbZLO6u0ySbYPrwzWiXBcC0WuHyhKKoeCyneH+FvYzKQq/zTtkQ==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.6.tgz",
+      "integrity": "sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA==",
+      "license": "MIT",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -615,6 +672,7 @@
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -635,6 +693,7 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -682,7 +741,8 @@
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -728,26 +788,16 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
       }
     },
     "node_modules/callsites": {
@@ -835,13 +885,15 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -918,32 +970,35 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.50",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.50.tgz",
-      "integrity": "sha512-X4CDiMnDbA3s3RaUXWXmgAIbY1uxab3fqe3qwzg5XutR3wjqi7M3IkgQbsIBzpqBN2YWr/Qdv7JrFRqSgb4TFg=="
+      "version": "0.37.119",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.119.tgz",
+      "integrity": "sha512-WasbGFXEB+VQWXlo6IpW3oUv73Yuau1Ig4AZF/m13tXcTKnMpc/mHjpztIlz4+BM9FG9BHQkEXiPto3bKduQUg==",
+      "license": "MIT"
     },
     "node_modules/discord.js": {
-      "version": "14.13.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.13.0.tgz",
-      "integrity": "sha512-Kufdvg7fpyTEwANGy9x7i4od4yu5c6gVddGi5CKm4Y5a6sF0VBODObI3o0Bh7TGCj0LfNT8Qp8z04wnLFzgnbA==",
+      "version": "14.18.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.18.0.tgz",
+      "integrity": "sha512-SvU5kVUvwunQhN2/+0t55QW/1EHfB1lp0TtLZUSXVHDmyHTrdOj5LRKdR0zLcybaA15F+NtdWuWmGOX9lE+CAw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@discordjs/builders": "^1.6.5",
-        "@discordjs/collection": "^1.5.3",
-        "@discordjs/formatters": "^0.3.2",
-        "@discordjs/rest": "^2.0.1",
-        "@discordjs/util": "^1.0.1",
-        "@discordjs/ws": "^1.0.1",
-        "@sapphire/snowflake": "^3.5.1",
-        "@types/ws": "^8.5.5",
-        "discord-api-types": "0.37.50",
-        "fast-deep-equal": "^3.1.3",
-        "lodash.snakecase": "^4.1.1",
-        "tslib": "^2.6.1",
-        "undici": "5.22.1",
-        "ws": "^8.13.0"
+        "@discordjs/builders": "^1.10.1",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.0",
+        "@discordjs/rest": "^2.4.3",
+        "@discordjs/util": "^1.1.1",
+        "@discordjs/ws": "^1.2.1",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "^0.37.119",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "tslib": "^2.6.3",
+        "undici": "6.21.1"
       },
       "engines": {
-        "node": ">=16.11.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/doctrine": {
@@ -959,10 +1014,11 @@
       }
     },
     "node_modules/ejs": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
-      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "jake": "^10.8.5"
       },
@@ -1238,10 +1294,11 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -1475,6 +1532,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -1591,7 +1649,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -1617,14 +1676,16 @@
       }
     },
     "node_modules/magic-bytes.js": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.5.0.tgz",
-      "integrity": "sha512-wJkXvutRbNWcc37tt5j1HyOK1nosspdh3dj6LUYYAvF6JYNqs53IfRvK9oEpcwiDA1NdoIi64yAMfdivPeVAyw=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.10.0.tgz",
+      "integrity": "sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ==",
+      "license": "MIT"
     },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node_modules/mdast-util-from-markdown": {
       "version": "1.3.1",
@@ -2115,12 +2176,13 @@
       ]
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -2506,14 +2568,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -2575,6 +2629,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -2600,14 +2655,16 @@
       }
     },
     "node_modules/ts-mixer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
-      "integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ=="
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
     },
     "node_modules/ts-node": {
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -2650,14 +2707,16 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -2696,14 +2755,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
-      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
-      "dependencies": {
-        "busboy": "^1.6.0"
-      },
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
+      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "license": "MIT",
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/unist-util-stringify-position": {
@@ -2749,7 +2806,8 @@
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -2804,9 +2862,10 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -2869,6 +2928,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2897,22 +2957,23 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "0.3.9"
       }
     },
     "@discordjs/builders": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.5.tgz",
-      "integrity": "sha512-SdweyCs/+mHj+PNhGLLle7RrRFX9ZAhzynHahMCLqp5Zeq7np7XC6/mgzHc79QoVlQ1zZtOkTTiJpOZu5V8Ufg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.10.1.tgz",
+      "integrity": "sha512-OWo1fY4ztL1/M/DUyRPShB4d/EzVfuUvPTRRHRIt/YxBrUYSz0a+JicD5F5zHFoNs2oTuWavxCOVFV1UljHTng==",
       "requires": {
-        "@discordjs/formatters": "^0.3.2",
-        "@discordjs/util": "^1.0.1",
-        "@sapphire/shapeshift": "^3.9.2",
-        "discord-api-types": "0.37.50",
+        "@discordjs/formatters": "^0.6.0",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.37.119",
         "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.3",
-        "tslib": "^2.6.1"
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
       }
     },
     "@discordjs/collection": {
@@ -2921,48 +2982,62 @@
       "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ=="
     },
     "@discordjs/formatters": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.2.tgz",
-      "integrity": "sha512-lE++JZK8LSSDRM5nLjhuvWhGuKiXqu+JZ/DsOR89DVVia3z9fdCJVcHF2W/1Zxgq0re7kCzmAJlCMMX3tetKpA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.0.tgz",
+      "integrity": "sha512-YIruKw4UILt/ivO4uISmrGq2GdMY6EkoTtD0oS0GvkJFRZbTSdPhzYiUILbJ/QslsvC9H9nTgGgnarnIl4jMfw==",
       "requires": {
-        "discord-api-types": "0.37.50"
+        "discord-api-types": "^0.37.114"
       }
     },
     "@discordjs/rest": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.0.1.tgz",
-      "integrity": "sha512-/eWAdDRvwX/rIE2tuQUmKaxmWeHmGealttIzGzlYfI4+a7y9b6ZoMp8BG/jaohs8D8iEnCNYaZiOFLVFLQb8Zg==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.4.3.tgz",
+      "integrity": "sha512-+SO4RKvWsM+y8uFHgYQrcTl/3+cY02uQOH7/7bKbVZsTfrfpoE62o5p+mmV+s7FVhTX82/kQUGGbu4YlV60RtA==",
       "requires": {
-        "@discordjs/collection": "^1.5.3",
-        "@discordjs/util": "^1.0.1",
-        "@sapphire/async-queue": "^1.5.0",
-        "@sapphire/snowflake": "^3.5.1",
-        "@vladfrangu/async_event_emitter": "^2.2.2",
-        "discord-api-types": "0.37.50",
-        "magic-bytes.js": "^1.0.15",
-        "tslib": "^2.6.1",
-        "undici": "5.22.1"
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.37.119",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.1"
+      },
+      "dependencies": {
+        "@discordjs/collection": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+          "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="
+        }
       }
     },
     "@discordjs/util": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.1.tgz",
-      "integrity": "sha512-d0N2yCxB8r4bn00/hvFZwM7goDcUhtViC5un4hPj73Ba4yrChLSJD8fy7Ps5jpTLg1fE9n4K0xBLc1y9WGwSsA=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1.tgz",
+      "integrity": "sha512-eddz6UnOBEB1oITPinyrB2Pttej49M9FZQY8NxgEvc3tq6ZICZ19m70RsmzRdDHk80O9NoYN/25AqJl8vPVf/g=="
     },
     "@discordjs/ws": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.0.1.tgz",
-      "integrity": "sha512-avvAolBqN3yrSvdBPcJ/0j2g42ABzrv3PEL76e3YTp2WYMGH7cuspkjfSyNWaqYl1J+669dlLp+YFMxSVQyS5g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.1.tgz",
+      "integrity": "sha512-PBvenhZG56a6tMWF/f4P6f4GxZKJTBG95n7aiGSPTnodmz4N5g60t79rSIAq7ywMbv8A4jFtexMruH+oe51aQQ==",
       "requires": {
-        "@discordjs/collection": "^1.5.3",
-        "@discordjs/rest": "^2.0.1",
-        "@discordjs/util": "^1.0.1",
-        "@sapphire/async-queue": "^1.5.0",
-        "@types/ws": "^8.5.5",
-        "@vladfrangu/async_event_emitter": "^2.2.2",
-        "discord-api-types": "0.37.50",
-        "tslib": "^2.6.1",
-        "ws": "^8.13.0"
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.4.3",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.37.119",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "dependencies": {
+        "@discordjs/collection": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+          "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="
+        }
       }
     },
     "@eslint-community/eslint-utils": {
@@ -3050,17 +3125,20 @@
     "@jridgewell/resolve-uri": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA=="
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "dev": true
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -3093,43 +3171,47 @@
       }
     },
     "@sapphire/async-queue": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
-      "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg=="
     },
     "@sapphire/shapeshift": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.2.tgz",
-      "integrity": "sha512-YRbCXWy969oGIdqR/wha62eX8GNHsvyYi0Rfd4rNW6tSVVa8p0ELiMEuOH/k8rgtvRoM+EMV7Csqz77YdwiDpA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "lodash": "^4.17.21"
       }
     },
     "@sapphire/snowflake": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.1.tgz",
-      "integrity": "sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA=="
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="
     },
     "@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
     },
     "@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
     },
     "@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
     },
     "@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
     },
     "@types/debug": {
       "version": "4.1.9",
@@ -3179,9 +3261,9 @@
       "dev": true
     },
     "@types/ws": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.6.tgz",
-      "integrity": "sha512-8B5EO9jLVCy+B58PLHvLDuOD8DRVMgQzq8d55SjLCOn9kqGyqOvy27exVaTio1q1nX5zLu8/6N0n2ThSxOM6tg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8svvI3hMyvN0kKCJMvTJP/x6Y/EoQbepff882wL+Sn5QsXb3etnamgrJq4isrBxSJj5L2AuXcI0+bgkoAXGUJw==",
       "requires": {
         "@types/node": "*"
       }
@@ -3287,14 +3369,15 @@
       }
     },
     "@vladfrangu/async_event_emitter": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.2.tgz",
-      "integrity": "sha512-HIzRG7sy88UZjBJamssEczH5q7t5+axva19UbZLO6u0ySbYPrwzWiXBcC0WuHyhKKoeCyneH+FvYzKQq/zTtkQ=="
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.6.tgz",
+      "integrity": "sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA=="
     },
     "acorn": {
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw=="
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -3306,7 +3389,8 @@
     "acorn-walk": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
     },
     "ajv": {
       "version": "6.12.6",
@@ -3338,7 +3422,8 @@
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "argparse": {
       "version": "2.0.1",
@@ -3381,20 +3466,12 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "requires": {
-        "fill-range": "^7.0.1"
-      }
-    },
-    "busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "requires": {
-        "streamsearch": "^1.1.0"
+        "fill-range": "^7.1.1"
       }
     },
     "callsites": {
@@ -3460,12 +3537,13 @@
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",
@@ -3519,29 +3597,27 @@
       }
     },
     "discord-api-types": {
-      "version": "0.37.50",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.50.tgz",
-      "integrity": "sha512-X4CDiMnDbA3s3RaUXWXmgAIbY1uxab3fqe3qwzg5XutR3wjqi7M3IkgQbsIBzpqBN2YWr/Qdv7JrFRqSgb4TFg=="
+      "version": "0.37.119",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.119.tgz",
+      "integrity": "sha512-WasbGFXEB+VQWXlo6IpW3oUv73Yuau1Ig4AZF/m13tXcTKnMpc/mHjpztIlz4+BM9FG9BHQkEXiPto3bKduQUg=="
     },
     "discord.js": {
-      "version": "14.13.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.13.0.tgz",
-      "integrity": "sha512-Kufdvg7fpyTEwANGy9x7i4od4yu5c6gVddGi5CKm4Y5a6sF0VBODObI3o0Bh7TGCj0LfNT8Qp8z04wnLFzgnbA==",
+      "version": "14.18.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.18.0.tgz",
+      "integrity": "sha512-SvU5kVUvwunQhN2/+0t55QW/1EHfB1lp0TtLZUSXVHDmyHTrdOj5LRKdR0zLcybaA15F+NtdWuWmGOX9lE+CAw==",
       "requires": {
-        "@discordjs/builders": "^1.6.5",
-        "@discordjs/collection": "^1.5.3",
-        "@discordjs/formatters": "^0.3.2",
-        "@discordjs/rest": "^2.0.1",
-        "@discordjs/util": "^1.0.1",
-        "@discordjs/ws": "^1.0.1",
-        "@sapphire/snowflake": "^3.5.1",
-        "@types/ws": "^8.5.5",
-        "discord-api-types": "0.37.50",
-        "fast-deep-equal": "^3.1.3",
-        "lodash.snakecase": "^4.1.1",
-        "tslib": "^2.6.1",
-        "undici": "5.22.1",
-        "ws": "^8.13.0"
+        "@discordjs/builders": "^1.10.1",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.0",
+        "@discordjs/rest": "^2.4.3",
+        "@discordjs/util": "^1.1.1",
+        "@discordjs/ws": "^1.2.1",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "^0.37.119",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "tslib": "^2.6.3",
+        "undici": "6.21.1"
       }
     },
     "doctrine": {
@@ -3554,9 +3630,9 @@
       }
     },
     "ejs": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
-      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "dev": true,
       "requires": {
         "jake": "^10.8.5"
@@ -3771,9 +3847,9 @@
       }
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
@@ -4060,14 +4136,15 @@
       }
     },
     "magic-bytes.js": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.5.0.tgz",
-      "integrity": "sha512-wJkXvutRbNWcc37tt5j1HyOK1nosspdh3dj6LUYYAvF6JYNqs53IfRvK9oEpcwiDA1NdoIi64yAMfdivPeVAyw=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.10.0.tgz",
+      "integrity": "sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ=="
     },
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "mdast-util-from-markdown": {
       "version": "1.3.1",
@@ -4337,12 +4414,12 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       }
     },
@@ -4582,11 +4659,6 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
-    "streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
-    },
     "string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -4650,14 +4722,15 @@
       "requires": {}
     },
     "ts-mixer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
-      "integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ=="
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
     },
     "ts-node": {
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -4677,14 +4750,15 @@
         "diff": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
         }
       }
     },
     "tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "type-check": {
       "version": "0.4.0",
@@ -4707,12 +4781,9 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
     },
     "undici": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
-      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
-      "requires": {
-        "busboy": "^1.6.0"
-      }
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
+      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ=="
     },
     "unist-util-stringify-position": {
       "version": "3.0.3",
@@ -4747,7 +4818,8 @@
     "v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "webidl-conversions": {
       "version": "3.0.1",
@@ -4790,9 +4862,9 @@
       "dev": true
     },
     "ws": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
       "requires": {}
     },
     "y18n": {
@@ -4831,7 +4903,8 @@
     "yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "beta_test": "npx tsc && npm run start"
   },
   "engines": {
-    "node": "18.9.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "discord.js": "^14.13.0",

--- a/src/commands/piracy-acts.ts
+++ b/src/commands/piracy-acts.ts
@@ -17,7 +17,10 @@ export const PiracyActs = [
   {
     name: 'admirals-orders',
     bounty: 3000,
-    description: 'Playing a Black deck, K.O. 5 characters through effect (e.g. Lucci\'s On-Play)',
+    description:
+      "Playing a Black deck, K.O. 5 characters through effect (e.g. Lucci's On-Play)",
+    category: 'Black'
+  },
   {
     name: 'this-is-my-age',
     bounty: 8000,
@@ -116,13 +119,14 @@ export const PiracyActs = [
     name: 'conqueror-haki',
     bounty: 5000,
     description:
-      'Have five different characters/ leader on the board that canonically have conqueror\'s haki',
+      "Have five different characters/ leader on the board that canonically have conqueror's haki",
     category: 'Multi-colour'
   },
   {
     name: 'shogun',
     bounty: 5000,
-    description: 'Have 4 different characters from the country of Wano on the board',
+    description:
+      'Have 4 different characters from the country of Wano on the board',
     category: 'Multi-colour'
   },
   {
@@ -142,13 +146,17 @@ export const PiracyActs = [
   {
     name: 'vinsmoke',
     bounty: 5000,
-    description: 'Transform 4 different Vinsmoke family members (Activation: Main)',
+    description:
+      'Transform 4 different Vinsmoke family members (Activation: Main)',
     category: 'Multi-colour'
   },
   {
     name: 'three-brothers',
     bounty: 7000,
-    description: 'Play the 3 brothers (adult version) on the same turn (Luffy, Ace, Sabo)',
+    description:
+      'Play the 3 brothers (adult version) on the same turn (Luffy, Ace, Sabo)',
+    category: 'Multi-colour'
+  },
   {
     name: 'whos-who',
     bounty: 5000,
@@ -168,7 +176,8 @@ export const PiracyActs = [
   {
     name: 'treasure-hunter',
     bounty: 1000,
-    description: 'Play 4 searches - could be character-based, event-based or even leader (must contain search in the effect)',
+    description:
+      'Play 4 searches - could be character-based, event-based or even leader (must contain search in the effect)',
     category: 'Generic'
   },
   {

--- a/src/commands/piracy-acts.ts
+++ b/src/commands/piracy-acts.ts
@@ -1,35 +1,79 @@
 export const PiracyActs = [
+  // Purple
   {
     name: 'kaido-drop',
     bounty: 5000,
     description: 'Play a 10-drop Purple Kaido and kill at least 7 characters',
     category: 'Purple'
   },
-  {
-    name: 'emperor-slayer',
-    bounty: 3000,
-    description:
-      'Kill any of: 10 drop Big Mom, 10 drop Kaido, 9 drop Shanks, 9 drop Edward Newgate',
-    category: 'Generic'
-  },
-  {
-    name: 'treasure-hunter',
-    bounty: 1000,
-    description: 'Play 4 searches (Leader abilities, card that puts more cards in your hand)',
-    category: 'Generic'
-  },
+
+  // Black
   {
     name: 'admirals-orders',
     bounty: 3000,
     description: 'Playing a Black deck, K.O. 5 characters through effect (e.g. Lucci\'s On-Play)',
     category: 'Black'
   },
+
+  // Red
   {
     name: 'two-year-training',
     bounty: 5000,
     description: 'Jet Pistol a Pacifista',
     category: 'Red'
   },
+  {
+    name: 'hayai',
+    bounty: 2000,
+    description: 'Play 2 characters with Rush on the same turn',
+    category: 'Red'
+  },
+
+  // Blue
+  {
+    name: 'cat-burglar',
+    bounty: 2000,
+    description:
+      'Win a game as OP03-040 Nami leader using secondary win con (No cards in deck)',
+    category: 'Blue'
+  },
+  {
+    name: 'red-roc',
+    bounty: 3000,
+    description: 'Bottom 3 characters with a Blue Event',
+    category: 'Blue'
+  },
+
+  // Yellow
+  {
+    name: 'o-nami',
+    bounty: 5000,
+    description: 'Successfully banish using O-Nami on-play ability',
+    category: 'Yellow'
+  },
+  {
+    name: 'satellite',
+    bounty: 5000,
+    description:
+      'Have 4 different Vegapunk Satellite characters on the board whilst playing Vegapunk Leader',
+    category: 'Yellow'
+  },
+
+  // Green
+  {
+    name: 'best-leader',
+    bounty: 5000,
+    description: 'Win a game with Hody Jones Leader OP06-20',
+    category: 'Green'
+  },
+  {
+    name: 'king-of-hell',
+    bounty: 5000,
+    description: 'Successfully land all 3 swings with OP06-118 Zoro',
+    category: 'Green'
+  },
+
+  // Multi-colour
   {
     name: 'straw-hat',
     bounty: 5000,
@@ -45,49 +89,10 @@ export const PiracyActs = [
     category: 'Multi-colour'
   },
   {
-    name: 'true-nakama',
-    bounty: 3000,
-    description: 'Block for your teammate in Buddy Battle',
-    category: 'Generic'
-  },
-  {
-    name: 'honesty-impact',
-    bounty: 15000,
-    description: 'K.O. a stage',
-    category: 'Generic'
-  },
-  {
-    name: 'cat-burglar',
-    bounty: 2000,
-    description:
-      'Win a game as OP03-040 Nami leader using secondary win con (No cards in deck)',
-    category: 'Blue'
-  },
-  {
     name: 'shogun',
     bounty: 5000,
     description: 'Have 4 different characters from the country of Wano on the board',
     category: 'Multi-colour'
-  },
-  {
-    name: 'one-mans-trash',
-    bounty: 5000,
-    description:
-      'Excluding Nami OP02 leader, have 40+ cards in your graveyard at any point during a game',
-    category: 'Generic'
-  },
-  {
-    name: 'assemble',
-    bounty: 3000,
-    description:
-      'Flood the board with 4 characters in a chain play (e.g. ST-13 Dadan and Film package)',
-    category: 'Generic'
-  },
-  {
-    name: 'sadge',
-    bounty: 5000,
-    description: 'One of your Ace characters gets K.O.d',
-    category: 'Generic'
   },
   {
     name: 'dressrosa',
@@ -115,41 +120,51 @@ export const PiracyActs = [
     description: 'Play the 3 brothers (adult version) on the same turn (Luffy, Ace, Sabo)',
     category: 'Multi-colour'
   },
+
+  // Generic
   {
-    name: 'hayai',
-    bounty: 2000,
-    description: 'Play 2 characters with Rush on the same turn',
-    category: 'Red'
-  },
-  {
-    name: 'red-roc',
+    name: 'emperor-slayer',
     bounty: 3000,
-    description: 'Bottom 3 characters with a Blue Event',
-    category: 'Blue'
+    description:
+      'Kill any of: 10 drop Big Mom, 10 drop Kaido, 9 drop Shanks, 9 drop Edward Newgate',
+    category: 'Generic'
   },
   {
-    name: 'o-nami',
-    bounty: 5000,
-    description: 'Successfully banish using O-Nami on-play ability',
-    category: 'Yellow'
+    name: 'treasure-hunter',
+    bounty: 1000,
+    description: 'Play 4 searches (Leader abilities, card that puts more cards in your hand)',
+    category: 'Generic'
   },
   {
-    name: 'satellite',
+    name: 'true-nakama',
+    bounty: 3000,
+    description: 'Block for your teammate in Buddy Battle',
+    category: 'Generic'
+  },
+  {
+    name: 'honesty-impact',
+    bounty: 15000,
+    description: 'K.O. a stage',
+    category: 'Generic'
+  },
+  {
+    name: 'one-mans-trash',
     bounty: 5000,
     description:
-      'Have 4 different Vegapunk Satellite characters on the board whilst playing Vegapunk Leader',
-    category: 'Yellow'
+      'Excluding Nami OP02 leader, have 40+ cards in your graveyard at any point during a game',
+    category: 'Generic'
   },
   {
-    name: 'best-leader',
-    bounty: 5000,
-    description: 'Win a game with Hody Jones Leader OP06-20',
-    category: 'Green'
+    name: 'assemble',
+    bounty: 3000,
+    description:
+      'Flood the board with 4 characters in a chain play (e.g. ST-13 Dadan and Film package)',
+    category: 'Generic'
   },
   {
-    name: 'king-of-hell',
+    name: 'sadge',
     bounty: 5000,
-    description: 'Successfully land all 3 swings with OP06-118 Zoro',
-    category: 'Green'
+    description: 'One of your Ace characters gets K.O.d',
+    category: 'Generic'
   }
 ];

--- a/src/commands/piracy-acts.ts
+++ b/src/commands/piracy-acts.ts
@@ -40,7 +40,7 @@ export const PiracyActs = [
   {
     name: 'red-roc',
     bounty: 3000,
-    description: 'Bottom 3 characters with a Blue Event',
+    description: 'Bottom 3 characters with Blue event cards',
     category: 'Blue'
   },
 
@@ -48,7 +48,7 @@ export const PiracyActs = [
   {
     name: 'o-nami',
     bounty: 5000,
-    description: 'Successfully banish using O-Nami on-play ability',
+    description: 'Successfully banish a life card using O-Nami On Play ability',
     category: 'Yellow'
   },
   {
@@ -132,7 +132,7 @@ export const PiracyActs = [
   {
     name: 'treasure-hunter',
     bounty: 1000,
-    description: 'Play 4 searches (Leader abilities, card that puts more cards in your hand)',
+    description: 'Play 4 searches - could be character-based, event-based or even leader (must contain search in the effect)',
     category: 'Generic'
   },
   {
@@ -158,13 +158,13 @@ export const PiracyActs = [
     name: 'assemble',
     bounty: 3000,
     description:
-      'Flood the board with 4 characters in a chain play (e.g. ST-13 Dadan and Film package)',
+      'Flood the board with 4 characters in one chain play (e.g. ST-13 Dadan and Film package)',
     category: 'Generic'
   },
   {
     name: 'sadge',
     bounty: 5000,
-    description: 'One of your Ace characters gets K.O.d',
+    description: 'One of your Portgas D. Ace characters gets K.O.d',
     category: 'Generic'
   }
 ];

--- a/src/commands/piracy-acts.ts
+++ b/src/commands/piracy-acts.ts
@@ -12,19 +12,32 @@ export const PiracyActs = [
     description: 'Use all four of your Gum Gum Giant event cards',
     category: 'Purple'
   },
+  {
+    name: 'all-according-to-keikaku',
+    bounty: 3000,
+    description:
+      'With Pluffy leader, go first, play Zoro-Juro ST18-004 on turn 2 and Luffy-Tarou ST18-005 plus San-Gorou ST18-003 on turn 3',
+    category: 'Purple'
+  },
 
   // Black
   {
     name: 'admirals-orders',
     bounty: 3000,
     description:
-      "Playing a Black deck, K.O. 5 characters through effect (e.g. Lucci's On-Play)",
+      "Playing a Lucci deck, K.O. 5 characters through effect",
     category: 'Black'
   },
   {
     name: 'this-is-my-age',
     bounty: 8000,
     description: 'Play all four of your 10C Blackbeards',
+    category: 'Black'
+  },
+  {
+    name: 'jack-of-all-trades',
+    bounty: 5000,
+    description: 'Using Jack OP08-084, remove from play a character with original cost of 8 or more',
     category: 'Black'
   },
 
@@ -83,6 +96,13 @@ export const PiracyActs = [
     bounty: 5000,
     description:
       'Have 4 different Vegapunk Satellite characters on the board whilst playing Vegapunk Leader',
+    category: 'Yellow'
+  },
+  {
+    name: 'no-life',
+    bounty: 2000,
+    description:
+      "Trash 2 of your opponent's life cards in one turn",
     category: 'Yellow'
   },
 

--- a/src/commands/piracy-acts.ts
+++ b/src/commands/piracy-acts.ts
@@ -2,65 +2,154 @@ export const PiracyActs = [
   {
     name: 'kaido-drop',
     bounty: 5000,
-    description: 'Kill 7 Characters with Purple 10-drop Kaido'
+    description: 'Play a 10-drop Purple Kaido and kill at least 7 characters',
+    category: 'Purple'
   },
   {
     name: 'emperor-slayer',
     bounty: 3000,
     description:
-      'Kill any of: 10 drop Big Mom, 10 drop Kaido, 9 drop Shanks, 9 drop Edward Newgate'
+      'Kill any of: 10 drop Big Mom, 10 drop Kaido, 9 drop Shanks, 9 drop Edward Newgate',
+    category: 'Generic'
   },
   {
     name: 'treasure-hunter',
     bounty: 1000,
-    description: 'Play 4 searcher cards'
+    description: 'Play 4 searches (Leader abilities, card that puts more cards in your hand)',
+    category: 'Generic'
   },
   {
     name: 'admirals-orders',
     bounty: 3000,
-    description: 'Playing a Black deck, K.O. 5 characters through effects'
+    description: 'Playing a Black deck, K.O. 5 characters through effect (e.g. Lucci\'s On-Play)',
+    category: 'Black'
   },
   {
     name: 'two-year-training',
-    bounty: 3000,
-    description: 'Jet Pistol a Pacifista'
+    bounty: 5000,
+    description: 'Jet Pistol a Pacifista',
+    category: 'Red'
   },
   {
     name: 'straw-hat',
     bounty: 5000,
-    description: 'Have 5 characters on the board that are different Straw Hats'
+    description:
+      'Have 4 different strawhat on the board that is also a different canonical character from your leader who is a strawhat',
+    category: 'Multi-colour'
   },
   {
     name: 'conqueror-haki',
     bounty: 5000,
     description:
-      'Have different 5 characters on the board that canonically have used Conquerors Haki'
+      'Have five different characters/ leader on the board that canonically have conqueror\'s haki',
+    category: 'Multi-colour'
   },
   {
     name: 'true-nakama',
     bounty: 3000,
-    description: 'Block for your teammate in Buddy Battle'
-  },
-  {
-    name: 'local-king',
-    bounty: 3000,
-    description: 'Win a local tournament'
+    description: 'Block for your teammate in Buddy Battle',
+    category: 'Generic'
   },
   {
     name: 'honesty-impact',
     bounty: 15000,
-    description: 'K.O. a Stage'
+    description: 'K.O. a stage',
+    category: 'Generic'
   },
   {
     name: 'cat-burglar',
     bounty: 2000,
     description:
-      'Win a game with OP03-040 Nami Leader secondary win condition: deck reaching zero cards'
+      'Win a game as OP03-040 Nami leader using secondary win con (No cards in deck)',
+    category: 'Blue'
   },
   {
     name: 'shogun',
+    bounty: 5000,
+    description: 'Have 4 different characters from the country of Wano on the board',
+    category: 'Multi-colour'
+  },
+  {
+    name: 'one-mans-trash',
+    bounty: 5000,
+    description:
+      'Excluding Nami OP02 leader, have 40+ cards in your graveyard at any point during a game',
+    category: 'Generic'
+  },
+  {
+    name: 'assemble',
     bounty: 3000,
     description:
-      'Have 5 characters on the board that are different Wano people'
+      'Flood the board with 4 characters in a chain play (e.g. ST-13 Dadan and Film package)',
+    category: 'Generic'
+  },
+  {
+    name: 'sadge',
+    bounty: 5000,
+    description: 'One of your Ace characters gets K.O.d',
+    category: 'Generic'
+  },
+  {
+    name: 'dressrosa',
+    bounty: 5000,
+    description:
+      'Have 4 different Dressrosa character on the board that is also different canonical character from your leader who is a Dressrosa',
+    category: 'Multi-colour'
+  },
+  {
+    name: 'warlords',
+    bounty: 5000,
+    description:
+      'Have 4 different Warlords of the Seven Sea character on the board that is also different canonical character from your leader who is a Warlord',
+    category: 'Multi-colour'
+  },
+  {
+    name: 'vinsmoke',
+    bounty: 5000,
+    description: 'Transform 4 different Vinsmoke family members (Activation: Main)',
+    category: 'Multi-colour'
+  },
+  {
+    name: 'three-brothers',
+    bounty: 7000,
+    description: 'Play the 3 brothers (adult version) on the same turn (Luffy, Ace, Sabo)',
+    category: 'Multi-colour'
+  },
+  {
+    name: 'hayai',
+    bounty: 2000,
+    description: 'Play 2 characters with Rush on the same turn',
+    category: 'Red'
+  },
+  {
+    name: 'red-roc',
+    bounty: 3000,
+    description: 'Bottom 3 characters with a Blue Event',
+    category: 'Blue'
+  },
+  {
+    name: 'o-nami',
+    bounty: 5000,
+    description: 'Successfully banish using O-Nami on-play ability',
+    category: 'Yellow'
+  },
+  {
+    name: 'satellite',
+    bounty: 5000,
+    description:
+      'Have 4 different Vegapunk Satellite characters on the board whilst playing Vegapunk Leader',
+    category: 'Yellow'
+  },
+  {
+    name: 'best-leader',
+    bounty: 5000,
+    description: 'Win a game with Hody Jones Leader OP06-20',
+    category: 'Green'
+  },
+  {
+    name: 'king-of-hell',
+    bounty: 5000,
+    description: 'Successfully land all 3 swings with OP06-118 Zoro',
+    category: 'Green'
   }
 ];

--- a/src/commands/piracy-acts.ts
+++ b/src/commands/piracy-acts.ts
@@ -13,12 +13,12 @@ export const PiracyActs = [
   {
     name: 'treasure-hunter',
     bounty: 1000,
-    description: 'Play 4 searches'
+    description: 'Play 4 searcher cards'
   },
   {
     name: 'admirals-orders',
     bounty: 3000,
-    description: 'Playing a Black deck, K.O. 5 characters through effect'
+    description: 'Playing a Black deck, K.O. 5 characters through effects'
   },
   {
     name: 'two-year-training',
@@ -28,13 +28,13 @@ export const PiracyActs = [
   {
     name: 'straw-hat',
     bounty: 5000,
-    description: 'Have 5 characters that are different Straw Hats on the board'
+    description: 'Have 5 characters on the board that are different Straw Hats'
   },
   {
     name: 'conqueror-haki',
     bounty: 5000,
     description:
-      'Have 5 different characters that canonically have Conquerors Haki'
+      'Have different 5 characters on the board that canonically have used Conquerors Haki'
   },
   {
     name: 'true-nakama',
@@ -42,9 +42,9 @@ export const PiracyActs = [
     description: 'Block for your teammate in Buddy Battle'
   },
   {
-    name: 'king',
+    name: 'local-king',
     bounty: 3000,
-    description: 'Win a tournament'
+    description: 'Win a local tournament'
   },
   {
     name: 'honesty-impact',
@@ -55,12 +55,12 @@ export const PiracyActs = [
     name: 'cat-burglar',
     bounty: 2000,
     description:
-      'Win a game with OP03-040 Nami Leader secondary win con'
+      'Win a game with OP03-040 Nami Leader secondary win condition: deck reaching zero cards'
   },
   {
     name: 'shogun',
     bounty: 3000,
     description:
-      'Have 5 different characters that are different Wano characters'
+      'Have 5 characters on the board that are different Wano people'
   }
 ];

--- a/src/commands/piracy-acts.ts
+++ b/src/commands/piracy-acts.ts
@@ -6,12 +6,22 @@ export const PiracyActs = [
     description: 'Play a 10-drop Purple Kaido and kill at least 7 characters',
     category: 'Purple'
   },
+  {
+    name: 'gentle-giant',
+    bounty: 5000,
+    description: 'Use all four of your Gum Gum Giant event cards',
+    category: 'Purple'
+  },
 
   // Black
   {
     name: 'admirals-orders',
     bounty: 3000,
     description: 'Playing a Black deck, K.O. 5 characters through effect (e.g. Lucci\'s On-Play)',
+  {
+    name: 'this-is-my-age',
+    bounty: 8000,
+    description: 'Play all four of your 10C Blackbeards',
     category: 'Black'
   },
 
@@ -26,6 +36,20 @@ export const PiracyActs = [
     name: 'hayai',
     bounty: 2000,
     description: 'Play 2 characters with Rush on the same turn',
+    category: 'Red'
+  },
+  {
+    name: 'divine-departure',
+    bounty: 3000,
+    description:
+      'Use the OP10 Divine Departure event to KO an Eustass Kid character',
+    category: 'Red'
+  },
+  {
+    name: 'king-of-pirates',
+    bounty: 6000,
+    description:
+      "Win the game by triggering Gol D Rogers' skill - not by damage",
     category: 'Red'
   },
 
@@ -70,6 +94,13 @@ export const PiracyActs = [
     name: 'king-of-hell',
     bounty: 5000,
     description: 'Successfully land all 3 swings with OP06-118 Zoro',
+    category: 'Green'
+  },
+  {
+    name: 'time-to-sleep',
+    bounty: 5000,
+    description:
+      'Rest/freeze the same opponent character three rounds in a row',
     category: 'Green'
   },
 
@@ -118,6 +149,11 @@ export const PiracyActs = [
     name: 'three-brothers',
     bounty: 7000,
     description: 'Play the 3 brothers (adult version) on the same turn (Luffy, Ace, Sabo)',
+  {
+    name: 'whos-who',
+    bounty: 5000,
+    description:
+      'While using a Punk Hazard leader, have 5 characters on the board who are body-swapped versions (ex. Sanji-nami, Chopper-sanji, Smoker-tashigi, ...)',
     category: 'Multi-colour'
   },
 

--- a/src/commands/piracy-acts.ts
+++ b/src/commands/piracy-acts.ts
@@ -1,44 +1,66 @@
-export const PiracyActs: string[] = [
-  'kaido-drop',
-  'emperor-slayer',
-  'treasure-hunter',
-  'admirals-orders',
-  'two-year-training',
-  'straw-hat',
-  'conqueror-haki',
-  'true-nakama',
-  'king',
-  'honesty-impact',
-  'cat-burglar',
-  'shogun'
-];
-
-export const Bounties = new Map<string, number>([
-  [PiracyActs[0], 5000],
-  [PiracyActs[1], 3000],
-  [PiracyActs[2], 1000],
-  [PiracyActs[3], 3000],
-  [PiracyActs[4], 3000],
-  [PiracyActs[5], 5000],
-  [PiracyActs[6], 5000],
-  [PiracyActs[7], 3000],
-  [PiracyActs[8], 3000],
-  [PiracyActs[9], 15000],
-  [PiracyActs[10], 2000],
-  [PiracyActs[11], 3000]
-]);
-
-export const BountiesDescription: string[] = [
-  'Kill 7 Characters with Purple 10-drop Kaido',
-  'Kill any of: 10 drop Big Mom, 10 drop Kaido, 9 drop Shanks, 9 drop Edward Newgate',
-  'Play 4 searches',
-  'Playing a Black deck, K.O. 5 characters through effect',
-  'Jet Pistol a Pacifista',
-  'Have 5 characters that are different Straw Hats on the board',
-  'Have 5 different characters that canonically have Conquerors Haki',
-  'Block for your teammate in Buddy Battle',
-  'Win a tournament',
-  'K.O. a Stage',
-  'Win a game with OP03-040 Nami Leader secondary win con',
-  'Have 5 different characters that are different Wano characters'
+export const PiracyActs = [
+  {
+    name: 'kaido-drop',
+    bounty: 5000,
+    description: 'Kill 7 Characters with Purple 10-drop Kaido'
+  },
+  {
+    name: 'emperor-slayer',
+    bounty: 3000,
+    description:
+      'Kill any of: 10 drop Big Mom, 10 drop Kaido, 9 drop Shanks, 9 drop Edward Newgate'
+  },
+  {
+    name: 'treasure-hunter',
+    bounty: 1000,
+    description: 'Play 4 searches'
+  },
+  {
+    name: 'admirals-orders',
+    bounty: 3000,
+    description: 'Playing a Black deck, K.O. 5 characters through effect'
+  },
+  {
+    name: 'two-year-training',
+    bounty: 3000,
+    description: 'Jet Pistol a Pacifista'
+  },
+  {
+    name: 'straw-hat',
+    bounty: 5000,
+    description: 'Have 5 characters that are different Straw Hats on the board'
+  },
+  {
+    name: 'conqueror-haki',
+    bounty: 5000,
+    description:
+      'Have 5 different characters that canonically have Conquerors Haki'
+  },
+  {
+    name: 'true-nakama',
+    bounty: 3000,
+    description: 'Block for your teammate in Buddy Battle'
+  },
+  {
+    name: 'king',
+    bounty: 3000,
+    description: 'Win a tournament'
+  },
+  {
+    name: 'honesty-impact',
+    bounty: 15000,
+    description: 'K.O. a Stage'
+  },
+  {
+    name: 'cat-burglar',
+    bounty: 2000,
+    description:
+      'Win a game with OP03-040 Nami Leader secondary win con'
+  },
+  {
+    name: 'shogun',
+    bounty: 3000,
+    description:
+      'Have 5 different characters that are different Wano characters'
+  }
 ];

--- a/src/commands/piracy-acts.ts
+++ b/src/commands/piracy-acts.ts
@@ -1,0 +1,44 @@
+export const PiracyActs: string[] = [
+  'kaido-drop',
+  'emperor-slayer',
+  'treasure-hunter',
+  'admirals-orders',
+  'two-year-training',
+  'straw-hat',
+  'conqueror-haki',
+  'true-nakama',
+  'king',
+  'honesty-impact',
+  'cat-burglar',
+  'shogun'
+];
+
+export const Bounties = new Map<string, number>([
+  [PiracyActs[0], 5000],
+  [PiracyActs[1], 3000],
+  [PiracyActs[2], 1000],
+  [PiracyActs[3], 3000],
+  [PiracyActs[4], 3000],
+  [PiracyActs[5], 5000],
+  [PiracyActs[6], 5000],
+  [PiracyActs[7], 3000],
+  [PiracyActs[8], 3000],
+  [PiracyActs[9], 15000],
+  [PiracyActs[10], 2000],
+  [PiracyActs[11], 3000]
+]);
+
+export const BountiesDescription: string[] = [
+  'Kill 7 Characters with Purple 10-drop Kaido',
+  'Kill any of: 10 drop Big Mom, 10 drop Kaido, 9 drop Shanks, 9 drop Edward Newgate',
+  'Play 4 searches',
+  'Playing a Black deck, K.O. 5 characters through effect',
+  'Jet Pistol a Pacifista',
+  'Have 5 characters that are different Straw Hats on the board',
+  'Have 5 different characters that canonically have Conquerors Haki',
+  'Block for your teammate in Buddy Battle',
+  'Win a tournament',
+  'K.O. a Stage',
+  'Win a game with OP03-040 Nami Leader secondary win con',
+  'Have 5 different characters that are different Wano characters'
+];

--- a/src/commands/piracy.ts
+++ b/src/commands/piracy.ts
@@ -1,51 +1,7 @@
 import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
 import * as database from '../utils/database';
 import * as poster from '../utils/poster';
-
-const PiracyActs: string[] = [
-  'kaido-drop',
-  'emperor-slayer',
-  'treasure-hunter',
-  'admirals-orders',
-  'two-year-training',
-  'straw-hat',
-  'conqeuror-haki',
-  'true-nakama',
-  'king',
-  'hoensty-impact',
-  'cat-burglar',
-  'shogun'
-];
-
-const Bounties = new Map<string, number>([
-  [PiracyActs[0], 5000],
-  [PiracyActs[1], 3000],
-  [PiracyActs[2], 1000],
-  [PiracyActs[3], 3000],
-  [PiracyActs[4], 3000],
-  [PiracyActs[5], 5000],
-  [PiracyActs[6], 5000],
-  [PiracyActs[7], 3000],
-  [PiracyActs[8], 3000],
-  [PiracyActs[9], 15000],
-  [PiracyActs[10], 2000],
-  [PiracyActs[11], 3000]
-]);
-
-const BountiesDescription: string[] = [
-  'Kill 7 Characters with Purple 10-drop Kaido',
-  'Kill any of: 10 drop Big Mom, 10 drop Kaido, 9 drop Shanks, 9 drop Edward Newgate',
-  'Play 4 searches',
-  'Playing a Black deck, K.O. 5 characters through effect',
-  'Jet Pistol a Pacifista',
-  'Have 5 characters that are different Straw Hats on the board',
-  'Have 5 different characters that canonically have Conquerors Haki',
-  'Block for your teammate in Buddy Battle',
-  'Win a tournament',
-  'K.O. a Stage',
-  'Win a game with OP03-040 Nami Leader secondary win con',
-  'Have 5 different characters that are different Wano characters'
-];
+import { PiracyActs, BountiesDescription, Bounties } from './piracy-acts';
 
 const PiracyCommand = new SlashCommandBuilder()
   .setName('piracy')

--- a/src/commands/piracy.ts
+++ b/src/commands/piracy.ts
@@ -1,20 +1,17 @@
 import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
 import * as database from '../utils/database';
 import * as poster from '../utils/poster';
-import { PiracyActs, BountiesDescription, Bounties } from './piracy-acts';
+import { PiracyActs } from './piracy-acts';
 
 const PiracyCommand = new SlashCommandBuilder()
   .setName('piracy')
   .setDescription('Report an act of piracy');
 
-for (let index = 0; index < PiracyActs.length; index++) {
-  const act = PiracyActs[index];
-  const description = BountiesDescription[index];
-
+PiracyActs.forEach((act) => {
   PiracyCommand.addSubcommand((subcommand) =>
     subcommand
-      .setName(act)
-      .setDescription(description)
+      .setName(act.name)
+      .setDescription(act.description)
       .addUserOption((option) =>
         option
           .setName('username')
@@ -22,7 +19,7 @@ for (let index = 0; index < PiracyActs.length; index++) {
           .setRequired(true)
       )
   );
-}
+});
 
 module.exports = {
   data: PiracyCommand,
@@ -31,24 +28,29 @@ module.exports = {
     await interaction.deferReply();
 
     const commandUsed = interaction.options.getSubcommand();
-    const bountyIncrease = Bounties.get(commandUsed);
+    const act = PiracyActs.find((act) => act.name === commandUsed);
 
-    if (!bountyIncrease) {
-      interaction.editReply('Something went wrong updating bounty');
+    if (!act) {
+      interaction.editReply('Cannot find the piracy act - try again later');
       return;
     }
+
     const username = interaction.options.getUser('username')?.username;
     if (!username) {
-      interaction.editReply(`No such user ${username}, please try again`);
+      interaction.editReply(`No such user ${username} - try again later`);
       return;
     }
-    const newBounty = await database.updateBounty(username, bountyIncrease);
+
+    const newBounty = await database.updateBounty(username, act.bounty);
+    // the pirate name on the board might not be the same as their discord username... I think (?)
     const pirateName = await database.getPirateName(username);
     const image = await database.getImageUrl(username);
 
     if (!pirateName || !image || !newBounty) {
       console.log('Failure interacting with database');
-      interaction.editReply('Something went wrong updating bounty');
+      interaction.editReply(
+        'Something went wrong updating bounty value for user - try again later'
+      );
       return;
     }
 
@@ -60,7 +62,7 @@ module.exports = {
 
     if (newPosterURL.length === 0) {
       console.log('Was not able to generate poster');
-      interaction.editReply('Something went wrong updating bounty');
+      interaction.editReply('Something went wrong updating bounty poster for user - try again later');
       return;
     }
 

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -94,7 +94,7 @@ async function updateBounty(
     const sql = postgres(DATABASE_URL, { ssl: 'require' });
     const data =
       await sql`update pirates set bounty = bounty + ${increase} where username=${name}
-    
+
     returning *`;
     if (data.length === 1) {
       return data[0].bounty; // new bounty
@@ -114,7 +114,7 @@ async function updatePoster(
     const sql = postgres(DATABASE_URL, { ssl: 'require' });
     const data =
       await sql`update pirates set poster_url = ${newURL} where username=${name}
-    
+
     returning *`;
     if (data.length === 1) {
       return data[0].poster_url;
@@ -134,7 +134,7 @@ async function updateOGImage(
     const sql = postgres(DATABASE_URL, { ssl: 'require' });
     const data =
       await sql`update pirates set image_url = ${newURL} where username=${name}
-    
+
     returning *`;
     if (data.length === 1) {
       return data[0].image_url;


### PR DESCRIPTION
## :warning: this is meant to only be reviewed&merged **AFTER** https://github.com/LoveGlitchCoffee/marinehq/pull/1

As per title, this PR adds a set of new events to the list. I tried to not add too many but also make it so there are at least a few more per each color.

Here's the recap of the new ones I'm proposing (it will be easier to check in the diff after PR 1 is merged):

### Purple
* `all-according-to-keikaku`: With Pluffy leader, go first, play Zoro-Juro ST18-004 on turn 2 and Luffy-Tarou ST18-005 plus San-Gorou ST18-003 on turn 3.
* `gentle-giant`: Use all four of your Gum Gum Giant event cards.

### Black
* `jack-of-all-trades`: Using Jack OP08-084, remove from play a character with original cost of 8 or more.
* `this-is-my-age`: Play all four of your 10C Blackbeards.

### Red
* `divine-departure`: Use the OP10 Divine Departure event to KO an Eustass Kid character.
* `king-of-pirates`: Win the game by triggering Gol D Rogers' skill - not by damage.

### Yellow
* `no-life`: Trash 2 of your opponent's life cards in one turn.

### Green
* `time-to-sleep`: Rest/freeze the same opponent character three rounds in a row.

### Multi-colour
* `whos-who`: While using a Punk Hazard leader, have 5 characters on the board who are body-swapped versions (e.g., Sanji-nami, Chopper-sanji, Smoker-tashigi, etc.).


My goal was to introduce events about newer sets (OP07->10) and more color-specific ones. Ideally I think a sweet spot should be 3-5 per each color.

Anyway, we can talk more details (and bounty values, etc) when we get to this being mergeable.